### PR TITLE
update linux rpm links

### DIFF
--- a/get_started/install/linux.md
+++ b/get_started/install/linux.md
@@ -30,15 +30,15 @@ If you build Qemu from source, don't forget enable virtfs (`--enable-virtfs`) du
 
 x86_64 binary packages:
 
-> - [hyper-0.5-1.el7.centos.x86_64.rpm](https://s3.amazonaws.com/hyper-install/hyper-0.5-1.el7.centos.x86_64.rpm)
-> -  [hyperstart-0.5-1.el7.centos.x86_64.rpm](https://s3.amazonaws.com/hyper-install/hyperstart-0.5-1.el7.centos.x86_64.rpm)
-> - [qemu-hyper-2.4.1-2.el7.centos.x86_64.rpm](https://s3.amazonaws.com/hyper-install/qemu-hyper-2.4.1-2.el7.centos.x86_64.rpm)
+> - [hyper-container-0.6-1.el7.centos.x86_64.rpm](http://hypercontainer-install.s3.amazonaws.com/hyper-container-0.6-1.el7.centos.x86_64.rpm)
+> - [hyperstart-0.6-1.el7.centos.x86_64.rpm](http://hypercontainer-install.s3.amazonaws.com/hyperstart-0.6-1.el7.centos.x86_64.rpm)
+> - [qemu-hyper-2.4.1-2.el7.centos.x86_64.rpm](http://hypercontainer-install.s3.amazonaws.com/qemu-hyper-2.4.1-2.el7.centos.x86_64.rpm)
 
 ## RPMs for Fedora 23
 
 x86_64 binary packages:
 
-> - [hyper-0.5-1.fc23.x86_64.rpm](https://s3.amazonaws.com/hyper-install/hyper-0.5-1.fc23.x86_64.rpm)
-> - [hyperstart-0.5-1.fc23.x86_64.rpm](https://s3.amazonaws.com/hyper-install/hyperstart-0.5-1.fc23.x86_64.rpm)
+> - [hyper-container-0.6-1.fc23.x86_64.rpm](http://hypercontainer-install.s3.amazonaws.com/hyper-container-0.6-1.fc23.x86_64.rpm)
+> - [hyperstart-0.6-1.fc23.x86_64.rpm](http://hypercontainer-install.s3.amazonaws.com/hyperstart-0.6-1.fc23.x86_64.rpm)
 
 > *Note*: The qemu shipped in Fedora could work well with Hyper, we did not package qemu for Fedora.


### PR DESCRIPTION
To point to the new S3 addresses for 0.6 release rpms.
