### PR TITLE
Fix the link to configuration file in build page

### DIFF
--- a/get_started/install/build.md
+++ b/get_started/install/build.md
@@ -46,4 +46,4 @@ Then you can find `hyper-initrd.img` in build directory, together with a pre-bui
 
 You can reference the [Hyper kernel configuration](https://github.com/hyperhq/hyperstart/blob/master/build/kernel_config).
 
-You can find related configuration items in [the config file](../reference/configuration.html).
+You can find related configuration items in [the config file](../../reference/configuration.html).


### PR DESCRIPTION
This page was moved to a deeper level but did not update the ref link.